### PR TITLE
blmp: migration strategy: FORK

### DIFF
--- a/include/linux/sched.h
+++ b/include/linux/sched.h
@@ -1129,6 +1129,25 @@ struct sched_avg {
 	u32 usage_avg_sum;
 };
 
+#ifdef CONFIG_SCHED_HMP
+/*
+ * We want to avoid boosting any processes forked from init (PID 1)
+ * and kthreadd (assumed to be PID 2).
+ *
+ * System services are generally started by init, whilst kernel threads are
+ * started by kthreadd. We do not want to give those tasks a head start, as
+ * this costs power for very little benefit. We do however wish to do that for
+ * tasks which the user launches.
+ *
+ * Further, some tasks allocate per-cpu timers directly after launch which can
+ * lead to those tasks being always scheduled on a big CPU when there is no
+ * computational need to do so. Not promoting services to big CPUs on launch
+ * will prevent that unless a service allocates their per-cpu resources after
+ * a period of intense computation, which is not a common pattern.
+ */
+#define hmp_task_should_forkboost(task) ((task->parent && task->parent->pid > 2))
+#endif
+
 #ifdef CONFIG_SCHEDSTATS
 struct sched_statistics {
 	u64			wait_start;

--- a/kernel/sched/core.c
+++ b/kernel/sched/core.c
@@ -1857,8 +1857,18 @@ static void __sched_fork(unsigned long clone_flags, struct task_struct *p)
 	p->se.avg.usage_avg_sum = 0;
 	p->se.avg.remainder = 0;
 #ifdef CONFIG_SCHED_HMP
+	/* keep LOAD_AVG_MAX in sync with fair.c if load avg series is changed */
+#define LOAD_AVG_MAX 47742
 	p->se.avg.hmp_last_up_migration = 0;
 	p->se.avg.hmp_last_down_migration = 0;
+	if (hmp_task_should_forkboost(p)) {
+		p->se.avg.load_avg_ratio = 1023;
+		p->se.avg.load_avg_contrib =
+				(1023 * scale_load_down(p->se.load.weight));
+		p->se.avg.runnable_avg_period = LOAD_AVG_MAX;
+		p->se.avg.runnable_avg_sum = LOAD_AVG_MAX;
+		p->se.avg.usage_avg_sum = LOAD_AVG_MAX;
+	}
 #ifdef CONFIG_HP_EVENT_HMP_SYSTEM_LOAD
 	p->se.avg.is_big_thread = false;
 #endif

--- a/kernel/sched/fair.c
+++ b/kernel/sched/fair.c
@@ -5888,6 +5888,19 @@ select_task_rq_fair(struct task_struct *p, int prev_cpu, int sd_flag, int wake_f
 	if (p->nr_cpus_allowed == 1)
 		return prev_cpu;
 
+#ifdef CONFIG_SCHED_HMP
+	/* always put non-kernel forking tasks on a big domain */
+	if (unlikely(sd_flag & SD_BALANCE_FORK) && hmp_task_should_forkboost(p)) {
+		new_cpu = hmp_select_faster_cpu(p, prev_cpu);
+		if (new_cpu != NR_CPUS) {
+			hmp_next_up_delay(&p->se, new_cpu);
+			return new_cpu;
+		}
+		/* failed to perform HMP fork balance, use normal balance */
+		new_cpu = cpu;
+	}
+#endif
+
 	if (sd_flag & SD_BALANCE_WAKE)
 		want_affine = cpumask_test_cpu(cpu, tsk_cpus_allowed(p));
 


### PR DESCRIPTION
Goals:
1. spawn new tasks on big cores, but
2. keep kernel threads and init task direct childs on the slower domain

System services are generally started by init, whilst kernel threads are
started by kthreadd. We do not want to give those tasks a head start, as
this costs power for very little benefit. We do however wish to do that
for tasks which the user launches.

Further, some tasks allocate per-cpu timers directly after launch which
can lead to those tasks being always scheduled on a big CPU when there
is no computational need to do so. Not promoting services to big CPUs on
launch will prevent that unless a service allocates their per-cpu
resources after a period of intense computation, which is not a common
pattern.

This is part of a consolidation of patches originally authored by:
Chris Redpath <chris.redpath@arm.com>
Dietmar Eggemann <dietmar.eggemann@arm.com>

Change-Id: I06b8fe1bb5b040b0931d008e27067350d8daa00c
Signed-off-by: Patrick Bellasi <patrick.bellasi@arm.com>
Signed-off-by: Jon Medhurst <tixy@linaro.org>
Signed-off-by: Jesse Chan <jc@linux.com>