### PR TITLE
gpu: remove connections between GPU and CPU frequency

### DIFF
--- a/drivers/gpu/arm/t8xx/r12p0/platform/exynos/gpu_integration_callbacks.c
+++ b/drivers/gpu/arm/t8xx/r12p0/platform/exynos/gpu_integration_callbacks.c
@@ -54,10 +54,6 @@
 extern int sec_therm_get_ap_temperature(void);
 #endif
 
-#ifdef CONFIG_SCHED_HMP
-extern int set_hmp_boost(int enable);
-#endif
-
 #ifdef CONFIG_USE_VSYNC_SKIP
 void decon_extra_vsync_wait_set(int);
 void decon_extra_vsync_wait_add(int);
@@ -148,11 +144,6 @@ void gpu_destroy_context(void *ctx)
 #ifdef CONFIG_MALI_DVFS
 		gpu_dvfs_boost_lock(GPU_DVFS_BOOST_UNSET);
 #endif
-#ifdef CONFIG_SCHED_HMP
-		set_hmp_boost(0);
-		set_hmp_aggressive_up_migration(false);
-		set_hmp_aggressive_yield(false);
-#endif
 	}
 }
 
@@ -219,11 +210,6 @@ int gpu_vendor_dispatch(struct kbase_context *kctx, void * const args, u32 args_
 #endif /* CONFIG_MALI_DVFS */
 			if (!kctx->ctx_need_qos) {
 				kctx->ctx_need_qos = true;
-#ifdef CONFIG_SCHED_HMP
-				set_hmp_boost(1);
-				set_hmp_aggressive_up_migration(true);
-				set_hmp_aggressive_yield(true);
-#endif
 			}
 #ifdef CONFIG_MALI_DVFS
 			platform = (struct exynos_context *) kbdev->platform_context;
@@ -239,11 +225,6 @@ int gpu_vendor_dispatch(struct kbase_context *kctx, void * const args, u32 args_
 #endif /* CONFIG_MALI_DVFS */
 			if (kctx->ctx_need_qos) {
 				kctx->ctx_need_qos = false;
-#ifdef CONFIG_SCHED_HMP
-				set_hmp_boost(0);
-				set_hmp_aggressive_up_migration(false);
-				set_hmp_aggressive_yield(false);
-#endif /* CONFIG_SCHED_HMP */
 #ifdef CONFIG_MALI_DVFS
 				platform = (struct exynos_context *) kbdev->platform_context;
 				gpu_pm_qos_command(platform, GPU_CONTROL_PM_QOS_EGL_RESET);


### PR DESCRIPTION
* We are forcing GPU to do surface composition currently.

* Hence GPU could be high-loaded more often than expected and GPUFreq-based
  CPUFreq boosts are battery-consuming and unneccessary in this situation.

Change-Id: If207dbb77f4ae846f170658d6f318e6e24889193